### PR TITLE
Backport changes from cookiecutter-django-girder v0.8

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: ./manage.py migrate
 web: gunicorn --bind 0.0.0.0:$PORT dkc.wsgi
-worker: REMAP_SIGTERM=SIGQUIT celery worker --app dkc.celery --loglevel info --without-heartbeat
+worker: REMAP_SIGTERM=SIGQUIT celery --app dkc.celery worker --loglevel INFO --without-heartbeat

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ but allows developers to run Python code on their native system.
    2. `./manage.py runserver`
 3. Run in a separate terminal:
    1. `source ./dev/source-native-env.sh`
-   2. `celery worker --app dkc.celery --loglevel info --without-heartbeat`
+   2. `celery --app dkc.celery worker --loglevel INFO --without-heartbeat`
 4. When finished, run `docker-compose stop`
 
 ## Remap Service Ports (optional)

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -22,9 +22,10 @@ services:
       context: .
       dockerfile: ./dev/django.Dockerfile
     command: [
-      "celery", "worker",
+      "celery",
       "--app", "dkc.celery",
-      "--loglevel", "info",
+      "worker",
+      "--loglevel", "INFO",
       "--without-heartbeat"
     ]
     # Docker Compose does not set the TTY width, which causes Celery errors

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -37,7 +37,7 @@ module "django" {
   subdomain_name   = "dkc-next"
 
   additional_django_vars = {
-    SENTRY_DSN = "https://a9897ae4723d4b0ab90c2856a342ba5a@o267860.ingest.sentry.io/5458971"
+    DJANGO_SENTRY_DSN = "https://a9897ae4723d4b0ab90c2856a342ba5a@o267860.ingest.sentry.io/5458971"
   }
   django_cors_origin_whitelist = ["https://${aws_route53_record.web.fqdn}"]
 }

--- a/tox.ini
+++ b/tox.ini
@@ -75,4 +75,3 @@ filterwarnings =
     ignore::DeprecationWarning:configurations
     # The DEFAULT_HASHING_ALGORITHM warning is caused by Django Configurations
     ignore:.*DEFAULT_HASHING_ALGORITHM.*:django.utils.deprecation.RemovedInDjango40Warning:django
-    ignore::django.utils.deprecation.RemovedInDjango40Warning:rest_framework


### PR DESCRIPTION
https://github.com/girder/cookiecutter-django-girder/releases/tag/v0.8