### PR TITLE
Add a Folder.iter_ancestors utility

### DIFF
--- a/dkc/core/models/folder.py
+++ b/dkc/core/models/folder.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import List, Type
+from typing import Iterator, Type
 
 from django.core import validators
 from django.core.exceptions import ValidationError
@@ -63,16 +63,12 @@ class Folder(TimeStampedModel, models.Model):
     def is_root(self) -> bool:
         return self.parent is None
 
-    def path_to_root(self) -> List[Folder]:
+    def iter_ancestors(self) -> Iterator[Folder]:
+        """Iterate up to the root of the Folder hierarchy, starting with this Folder."""
         folder = self
-        path = [folder]
-        while not folder.is_root:
+        while folder is not None:
+            yield folder
             folder = folder.parent
-            path.append(folder)
-            if len(path) > self.MAX_TREE_HEIGHT:
-                raise MaxFolderDepthExceeded()
-
-        return path[::-1]
 
     def clean(self) -> None:
         if self.parent and self.parent.files.filter(name=self.name).exists():

--- a/dkc/core/rest/folder.py
+++ b/dkc/core/rest/folder.py
@@ -35,5 +35,7 @@ class FolderViewSet(ModelViewSet):
     @action(detail=True)
     def path(self, request, pk=None):
         folder = self.get_object()
-        serializer = self.get_serializer(folder.path_to_root(), many=True)
+        # Start with the root folder
+        ancestors = list(folder.iter_ancestors())[::-1]
+        serializer = self.get_serializer(ancestors, many=True)
         return Response(serializer.data)

--- a/dkc/core/tests/test_folder.py
+++ b/dkc/core/tests/test_folder.py
@@ -35,6 +35,13 @@ def test_is_root_child(folder_factory):
     assert child.is_root is False
 
 
+def test_iter_ancestors(folder_factory):
+    folder = folder_factory.build()
+    child = folder_factory.build(parent=folder)
+    grandchild = folder_factory.build(parent=child)
+    assert list(grandchild.iter_ancestors()) == [grandchild, child, folder]
+
+
 @pytest.mark.django_db
 def test_root_folder_depth_is_zero(folder):
     assert folder.depth == 0


### PR DESCRIPTION
This should be useful for various traversal operations, particularly for migration scripts.