### PR TITLE
Disallow changing folder's parent via REST API

### DIFF
--- a/dkc/core/rest/folder.py
+++ b/dkc/core/rest/folder.py
@@ -16,6 +16,12 @@ class FolderSerializer(serializers.ModelSerializer):
         fields = ['id', 'name', 'description', 'parent', 'created', 'modified', 'size']
 
 
+class FolderUpdateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Folder
+        fields = ['id', 'name', 'description']
+
+
 class FoldersFilterSet(filters.FilterSet):
     parent = IntegerOrNullFilter(required=True)
 
@@ -27,10 +33,14 @@ class FolderViewSet(ModelViewSet):
         AllowAny,
         # IsAuthenticatedOrReadOnly,
     ]
-    serializer_class = FolderSerializer
 
     filter_backends = [ActionSpecificFilterBackend]
     filterset_class = FoldersFilterSet
+
+    def get_serializer_class(self):
+        if self.request.method in ['PUT', 'PATCH']:
+            return FolderUpdateSerializer
+        return FolderSerializer
 
     @action(detail=True)
     def path(self, request, pk=None):

--- a/dkc/core/rest/folder.py
+++ b/dkc/core/rest/folder.py
@@ -16,9 +16,8 @@ class FolderSerializer(serializers.ModelSerializer):
         fields = ['id', 'name', 'description', 'parent', 'created', 'modified', 'size']
 
 
-class FolderUpdateSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Folder
+class FolderUpdateSerializer(FolderSerializer):
+    class Meta(FolderSerializer.Meta):
         fields = ['id', 'name', 'description']
 
 
@@ -38,7 +37,7 @@ class FolderViewSet(ModelViewSet):
     filterset_class = FoldersFilterSet
 
     def get_serializer_class(self):
-        if self.request.method in ['PUT', 'PATCH']:
+        if self.action in ['update', 'partial_update']:
             return FolderUpdateSerializer
         return FolderSerializer
 


### PR DESCRIPTION
PTAL. Prior to this change, it was possible to alter a folder's parent reference via a REST update.