### PR TITLE
Ensure that all transitive requirements are installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'django-allauth',
         'django-click',
         'django-composed-configuration[dev,prod]>=0.10.0',
-        'django-configurations',
+        'django-configurations[database,email]',
         'django-extensions',
         'django-filter',
         'django-girder-utils',


### PR DESCRIPTION
The old pip resolver does not properly fetch transitive requirements in certain cases. Until the new pip resolver is available more consistently, this works around the bug.