### PR TITLE
Use the actual authenticated user in REST endpoints

### DIFF
--- a/dkc/core/rest/folder.py
+++ b/dkc/core/rest/folder.py
@@ -107,8 +107,7 @@ class FolderViewSet(ModelViewSet):
         except Terms.DoesNotExist:
             return Response(status=204)  # No terms for the folder
 
-        # TODO get the actual user once REST authentication is in place
-        user = User.objects.first()
+        user = request.user
 
         # TODO if no user is authenticated, just send out the terms.
 
@@ -147,8 +146,7 @@ class FolderViewSet(ModelViewSet):
                 {'checksum': 'Mismatched checksum. Your terms may be out of date.'}
             )
 
-        # TODO get the actual user once REST authentication is in place
-        user = User.objects.first()
+        user = request.user
 
         TermsAgreement.objects.update_or_create(
             terms=terms, user=user, defaults={'checksum': checksum}


### PR DESCRIPTION
Also, require an authenticated user to call the terms/agreement endpoints and refactor the test names for agreement tests.


Fixes #111 