### PR TITLE
Set serializer class on UserViewSet

### DIFF
--- a/dkc/core/rest/user.py
+++ b/dkc/core/rest/user.py
@@ -19,6 +19,7 @@ class UserViewSet(GenericViewSet):
     queryset = User.objects.all()
 
     permission_classes = [AllowAny]
+    serializer_class = UserSerializer
 
     @action(detail=False, pagination_class=None)
     def me(self, request):


### PR DESCRIPTION
This addresses an assertion error I noticed on Sentry:

```'UserViewSet' should either include a `serializer_class` attribute, or override the `get_serializer_class()` method.```