### PR TITLE
Allow explicit permissions to be added for superusers

### DIFF
--- a/dkc/core/models/tree.py
+++ b/dkc/core/models/tree.py
@@ -79,9 +79,6 @@ class Tree(models.Model):
 
     def _get_user_permissions(self, user: User) -> Set[Permission]:
         permission_strings = {p.value for p in Permission}
-        if user.is_superuser:
-            return set(Permission)
-
         user_perms = get_user_perms(user, self)
         return {Permission(p) for p in user_perms if p in permission_strings}
 

--- a/dkc/core/tests/test_permissions.py
+++ b/dkc/core/tests/test_permissions.py
@@ -324,3 +324,13 @@ def test_file_create_permission_enforcement(api_client, folder, user, s3ff_field
         },
     )
     assert resp.status_code == 403
+
+
+@pytest.mark.django_db
+def test_set_admin_permission(user_factory, folder):
+    admin = user_factory(is_superuser=True)
+    grant = PermissionGrant(user_or_group=admin, permission=Permission.read)
+    tree = folder.tree
+
+    tree.grant_permission(grant)
+    assert grant in tree.list_granted_permissions()


### PR DESCRIPTION
This fixes something that could be seen as a bug where permissions weren't actually being added for superusers.  There is no behavioral change here because superusers can always do anything anyway.

Alternatively, we could make it so superusers are always included in the list of permissions returned by `GET /folders/{id}/permissions`.  This has the problem that the implicit super user permissions couldn't be removed, and it would expose a global list of superusers to everyone.