### PR TITLE
Use pytest-randomly to set a consistent random seed

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ deps =
     pytest-django
     pytest-factoryboy
     pytest-mock
+    pytest-randomly
 commands =
     pytest {posargs}
 
@@ -69,7 +70,7 @@ ignore =
 [pytest]
 DJANGO_SETTINGS_MODULE = dkc.settings
 DJANGO_CONFIGURATION = TestingConfiguration
-addopts = --strict-markers --showlocals --verbose
+addopts = --strict-markers --showlocals --verbose --randomly-seed=0
 filterwarnings =
     ignore::DeprecationWarning:minio
     ignore::DeprecationWarning:configurations


### PR DESCRIPTION
Should prevent the random testing errors that we get due to name constraints.