### PR TITLE
Rework FolderSerializer to use native DRF validation

### DIFF
--- a/dkc/core/models/folder.py
+++ b/dkc/core/models/folder.py
@@ -116,9 +116,7 @@ class Folder(TimeStampedModel, models.Model):
 
     def clean(self) -> None:
         if self.parent and self.parent.files.filter(name=self.name).exists():
-            raise ValidationError(
-                {'name': f'There is already a file here with the name "{self.name}".'}
-            )
+            raise ValidationError({'name': 'A file with that name already exists here.'})
         super().clean()
 
     @classmethod

--- a/dkc/core/rest/folder.py
+++ b/dkc/core/rest/folder.py
@@ -47,14 +47,14 @@ class FolderSerializer(serializers.ModelSerializer):
             serializers.UniqueTogetherValidator(
                 queryset=Folder.objects.all(),
                 fields=['parent', 'name'],
-                message='Folder names must be unique among siblings.',
+                message='A folder with that name already exists here.',
             ),
             # This could also be implemented as a UniqueValidator on 'name',
             # but its easier to not explicitly redefine the whole serializer field
             serializers.UniqueTogetherValidator(
                 queryset=Folder.objects.filter(parent=None),
                 fields=['name'],
-                message='Root folders must have a unique name.',
+                message='A root folder with that name already exists.',
             ),
             # folder_max_depth and unique_root_folder_per_tree are internal sanity constraints,
             # and do not need to be enforced as validators

--- a/dkc/core/rest/folder.py
+++ b/dkc/core/rest/folder.py
@@ -23,6 +23,7 @@ from dkc.core.permissions import (
 )
 
 from .filtering import ActionSpecificFilterBackend, IntegerOrNullFilter
+from .utils import FormattableDict
 
 
 class FolderSerializer(serializers.ModelSerializer):
@@ -47,14 +48,14 @@ class FolderSerializer(serializers.ModelSerializer):
             serializers.UniqueTogetherValidator(
                 queryset=Folder.objects.all(),
                 fields=['parent', 'name'],
-                message='A folder with that name already exists here.',
+                message=FormattableDict({'name': 'A folder with that name already exists here.'}),
             ),
             # This could also be implemented as a UniqueValidator on 'name',
             # but its easier to not explicitly redefine the whole serializer field
             serializers.UniqueTogetherValidator(
                 queryset=Folder.objects.filter(parent=None),
                 fields=['name'],
-                message='A root folder with that name already exists.',
+                message=FormattableDict({'name': 'A root folder with that name already exists.'}),
             ),
             # folder_max_depth and unique_root_folder_per_tree are internal sanity constraints,
             # and do not need to be enforced as validators
@@ -80,7 +81,7 @@ class FolderSerializer(serializers.ModelSerializer):
             parent_id = attrs['parent_id'] if 'parent_id' in attrs else self.instance.parent_id
         if parent_id is not None and File.objects.filter(name=name, folder_id=parent_id).exists():
             raise serializers.ValidationError(
-                'A file with that name already exists here.', code='unique'
+                {'name': 'A file with that name already exists here.'}, code='unique'
             )
 
 

--- a/dkc/core/rest/folder.py
+++ b/dkc/core/rest/folder.py
@@ -78,7 +78,7 @@ class FolderSerializer(serializers.ModelSerializer):
             # Update
             # On a partial update, 'name' and 'parent' might be absent, so use the existing instance
             name = attrs['name'] if 'name' in attrs else self.instance.name
-            parent_id = attrs['parent_id'] if 'parent_id' in attrs else self.instance.parent_id
+            parent_id = attrs['parent'] if 'parent' in attrs else self.instance.parent_id
         if parent_id is not None and File.objects.filter(name=name, folder_id=parent_id).exists():
             raise serializers.ValidationError(
                 {'name': 'A file with that name already exists here.'}, code='unique'

--- a/dkc/core/rest/utils.py
+++ b/dkc/core/rest/utils.py
@@ -20,3 +20,14 @@ class FullCleanModelSerializer(serializers.ModelSerializer):
             except DjangoValidationError as exc:
                 raise serializers.ValidationError(serializers.as_serializer_error(exc))
         return data
+
+
+class FormattableDict(dict):
+    """
+    A dict with a no-op .format method.
+
+    This is useful to pass into DRF, as the `message` of an eventual `ValidationError`.
+    """
+
+    def format(self, *args, **kwargs):
+        return self

--- a/dkc/core/tests/test_folder.py
+++ b/dkc/core/tests/test_folder.py
@@ -1,5 +1,3 @@
-import re
-
 from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
 import pytest
@@ -73,11 +71,8 @@ def test_folder_sibling_names_unique(folder, folder_factory):
 
 @pytest.mark.django_db
 def test_folder_sibling_names_unique_files(file, folder_factory):
-    escaped = re.escape(file.name)
     sibling_folder = folder_factory.build(parent=file.folder, name=file.name)
-    with pytest.raises(
-        ValidationError, match=fr'There is already a file here with the name "{escaped}"\.'
-    ):
+    with pytest.raises(ValidationError, match='A file with that name already exists here.'):
         sibling_folder.full_clean()
 
 

--- a/dkc/core/tests/test_folder_rest.py
+++ b/dkc/core/tests/test_folder_rest.py
@@ -54,7 +54,7 @@ def test_folder_rest_create_invalid_parent(admin_api_client, parent):
 
 @pytest.mark.django_db
 def test_folder_rest_create_invalid_duplicate_root(admin_api_client, folder):
-    resp = admin_api_client.post('/api/v2/folders', data={'name': folder.name})
+    resp = admin_api_client.post('/api/v2/folders', data={'name': folder.name, 'parent': None})
     assert resp.status_code == 400
     assert 'non_field_errors' in resp.data
 
@@ -70,7 +70,7 @@ def test_folder_rest_create_invalid_duplicate_sibling(admin_api_client, child_fo
 
 @pytest.mark.django_db
 def test_folder_rest_create_root(admin_api_client):
-    resp = admin_api_client.post('/api/v2/folders', data={'name': 'test folder'})
+    resp = admin_api_client.post('/api/v2/folders', data={'name': 'test folder', 'parent': None})
     assert resp.status_code == 201
     assert Folder.objects.count() == 1
 

--- a/dkc/core/tests/test_folder_rest.py
+++ b/dkc/core/tests/test_folder_rest.py
@@ -79,6 +79,20 @@ def test_folder_rest_create_invalid_duplicate_sibling_file(admin_api_client, fol
 
 
 @pytest.mark.django_db
+def test_folder_rest_create_invalid_duplicate_sibling_file_update(
+    admin_api_client, folder, file_factory, folder_factory
+):
+    # Since this is implemented with an explicitly separate code path, it deserves its own test
+    child_file = file_factory(folder=folder)
+    child_folder = folder_factory(parent=folder)
+    resp = admin_api_client.patch(
+        f'/api/v2/folders/{child_folder.id}', data={'name': child_file.name}
+    )
+    assert resp.status_code == 400
+    assert 'name' in resp.data
+
+
+@pytest.mark.django_db
 def test_folder_rest_create_root(admin_api_client):
     resp = admin_api_client.post('/api/v2/folders', data={'name': 'test folder', 'parent': None})
     assert resp.status_code == 201

--- a/dkc/core/tests/test_folder_rest.py
+++ b/dkc/core/tests/test_folder_rest.py
@@ -95,7 +95,7 @@ def test_folder_rest_retrieve(admin_api_client, folder):
 
 @pytest.mark.django_db
 def test_folder_rest_update(admin_api_client, folder):
-    resp = admin_api_client.put(
+    resp = admin_api_client.patch(
         f'/api/v2/folders/{folder.id}', data={'name': 'New name', 'description': 'New description'}
     )
     assert resp.status_code == 200

--- a/dkc/core/tests/test_folder_rest.py
+++ b/dkc/core/tests/test_folder_rest.py
@@ -56,7 +56,7 @@ def test_folder_rest_create_invalid_parent(admin_api_client, parent):
 def test_folder_rest_create_invalid_duplicate_root(admin_api_client, folder):
     resp = admin_api_client.post('/api/v2/folders', data={'name': folder.name, 'parent': None})
     assert resp.status_code == 400
-    assert 'non_field_errors' in resp.data
+    assert 'name' in resp.data
 
 
 @pytest.mark.django_db
@@ -65,7 +65,7 @@ def test_folder_rest_create_invalid_duplicate_sibling_folder(admin_api_client, c
         '/api/v2/folders', data={'name': child_folder.name, 'parent': child_folder.parent.id}
     )
     assert resp.status_code == 400
-    assert 'non_field_errors' in resp.data
+    assert 'name' in resp.data
 
 
 @pytest.mark.django_db
@@ -75,7 +75,7 @@ def test_folder_rest_create_invalid_duplicate_sibling_file(admin_api_client, fol
         '/api/v2/folders', data={'name': child_file.name, 'parent': folder.id}
     )
     assert resp.status_code == 400
-    assert 'non_field_errors' in resp.data
+    assert 'name' in resp.data
 
 
 @pytest.mark.django_db

--- a/dkc/core/tests/test_folder_rest.py
+++ b/dkc/core/tests/test_folder_rest.py
@@ -60,9 +60,19 @@ def test_folder_rest_create_invalid_duplicate_root(admin_api_client, folder):
 
 
 @pytest.mark.django_db
-def test_folder_rest_create_invalid_duplicate_sibling(admin_api_client, child_folder):
+def test_folder_rest_create_invalid_duplicate_sibling_folder(admin_api_client, child_folder):
     resp = admin_api_client.post(
         '/api/v2/folders', data={'name': child_folder.name, 'parent': child_folder.parent.id}
+    )
+    assert resp.status_code == 400
+    assert 'non_field_errors' in resp.data
+
+
+@pytest.mark.django_db
+def test_folder_rest_create_invalid_duplicate_sibling_file(admin_api_client, folder, file_factory):
+    child_file = file_factory(folder=folder)
+    resp = admin_api_client.post(
+        '/api/v2/folders', data={'name': child_file.name, 'parent': folder.id}
     )
     assert resp.status_code == 400
     assert 'non_field_errors' in resp.data

--- a/dkc/core/tests/test_permissions.py
+++ b/dkc/core/tests/test_permissions.py
@@ -278,7 +278,7 @@ def test_delete_permissions(api_client, user, user_factory, admin_folder):
 @pytest.mark.django_db
 def test_root_folder_create_sets_permissions(api_client, user):
     api_client.force_authenticate(user=user)
-    resp = api_client.post('/api/v2/folders', data={'name': 'test'})
+    resp = api_client.post('/api/v2/folders', data={'name': 'test', 'parent': None})
     assert resp.status_code == 201
     assert resp.data['public'] is False
     assert resp.data['access'] == {'read': True, 'write': True, 'admin': True}


### PR DESCRIPTION
`FullCleanModelSerializer` does not work properly with internally-set fields like `tree`, since the value is not available at the time of initial validation. Currently, it only works because `tree` has `editable=False`, so the Model-layer validator skips the field.

See [this comment](https://github.com/girder/dkc-next/pull/64#discussion_r567090441) for more information on the problem.

This refactor also has the result of effectively removing the default of `parent=None` when creating a folder. This is probably a net benefit, as it forces API clients to be explicit when creating a new root folder.

Also:
* Add tests for POSTing invalid Folder values
* Test folder updates with a PATCH request