### PR TITLE
Use a sequence to ensure that factories produce unique output

### DIFF
--- a/dkc/core/tests/factories.py
+++ b/dkc/core/tests/factories.py
@@ -19,22 +19,25 @@ class UserFactory(factory.django.DjangoModelFactory):
 
 
 class TreeFactory(factory.django.DjangoModelFactory):
-    public = False
-    # No need to instantiate a quota, just fetch from the user creating this
-    quota = factory.SelfAttribute('creator.quota')
-
     class Meta:
         model = Tree
 
     class Params:
         creator = factory.SubFactory(UserFactory)
 
+    public = False
+    # No need to instantiate a quota, just fetch from the user creating this
+    quota = factory.SelfAttribute('creator.quota')
+
 
 class FolderFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Folder
 
-    name = factory.Faker('word')
+    class Params:
+        name_base = factory.Faker('word')
+
+    name = factory.LazyAttributeSequence(lambda o, n: f'{o.name_base}-{n}')
     description = factory.Faker('paragraph')
     user_metadata = _metadata_faker
     parent = None
@@ -51,7 +54,11 @@ class FileFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = File
 
-    name = factory.Faker('file_name')
+    class Params:
+        name_base = factory.Faker('word')
+        name_ext = factory.Faker('file_extension')
+
+    name = factory.LazyAttributeSequence(lambda o, n: f'{o.name_base}-{n}.{o.name_ext}')
     description = factory.Faker('paragraph')
     blob = factory.django.FileField(data=b'fakefilebytes', filename='fake.txt')
     user_metadata = _metadata_faker

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,6 @@ deps =
     pytest-django
     pytest-factoryboy
     pytest-mock
-    pytest-randomly
 commands =
     pytest {posargs}
 
@@ -70,7 +69,7 @@ ignore =
 [pytest]
 DJANGO_SETTINGS_MODULE = dkc.settings
 DJANGO_CONFIGURATION = TestingConfiguration
-addopts = --strict-markers --showlocals --verbose --randomly-seed=0
+addopts = --strict-markers --showlocals --verbose
 filterwarnings =
     ignore::DeprecationWarning:minio
     ignore::DeprecationWarning:configurations


### PR DESCRIPTION
Using a fixed random seed only ensures that the current set of tests consistently succeed, but there's no guarantee that future tests will continue to be lucky. Additionally, using the `mock_db` tool can still result in illegal duplicates.

The pattern of using Factory Boy Sequences with Faker was suggested by: https://github.com/FactoryBoy/factory_boy/issues/835