### PR TITLE
Add werkzeug in dev to enable runserver_plus

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ setup(
             'django-debug-toolbar',
             'ipython',
             'tox',
+            'werkzeug',
         ]
     },
 )


### PR DESCRIPTION
Pushing this as an RFC. After @danlamanna showed off the `--print-sql` mode of `runserver_plus` I used it locally and it's excellent, and I anticipate wanting it more in the future. Adding it to the dev dependencies lets me just modify the docker compose config to add whatever arguments I want.