### PR TITLE
Select related 'tree' on folder REST lookups

### DIFF
--- a/dkc/core/rest/folder.py
+++ b/dkc/core/rest/folder.py
@@ -162,7 +162,8 @@ class FolderPublicSerializer(serializers.Serializer):
 
 
 class FolderViewSet(ModelViewSet):
-    queryset = Folder.objects.all()
+    # Tree info is required for 'public' and 'access' serializer fields
+    queryset = Folder.objects.select_related('tree')
 
     permission_classes = [HasAccess]
 


### PR DESCRIPTION
This fixes n+1 query bug on folder listing due to the presence of `access` and `public` fields in the serializer.