### PR TITLE
Compute file SHA512 on upload

### DIFF
--- a/dkc/core/models/file.py
+++ b/dkc/core/models/file.py
@@ -88,7 +88,6 @@ class File(TimeStampedModel, models.Model):
 
 @receiver(models.signals.pre_save, sender=File)
 def _file_pre_save(sender: Type[File], instance: File, **kwargs):
-    # TODO if we allow changing a file's blob & size, we'll need more logic here
     if not instance.pk:
         instance.folder.increment_size(instance.size)
 

--- a/dkc/core/rest/file.py
+++ b/dkc/core/rest/file.py
@@ -118,21 +118,25 @@ class FileViewSet(ModelViewSet):
             )
 
     def perform_update(self, serializer: FileUpdateSerializer) -> None:
-        with transaction.atomic():
-            # We lock this file row in order to make sure `blob` can only be set once.
-            # This ensures that we launch at most one `file_compute_sha512` async jobs.
-            # If we didn't have atomicity on this operation, it would be possible to
-            # create a race condition between async hashing jobs that could cause a
-            # mismatch between the blob and the checksum. Aside from security implications,
-            # violations of the immutable blob policy could also cause data integrity failures.
-            file: File = File.objects.select_for_update().get(pk=serializer.instance.pk)
-            if file.blob and 'blob' in serializer.validated_data:
-                raise serializers.ValidationError({'blob': ["A file's blob may only be set once."]})
-
-            serializer.save()
-
         if 'blob' in serializer.validated_data:
+            with transaction.atomic():
+                # We lock this file row in order to make sure `blob` can only be set once.
+                # This ensures that we launch at most one `file_compute_sha512` async jobs.
+                # If we didn't have atomicity on this operation, it would be possible to
+                # create a race condition between async hashing jobs that could cause a
+                # mismatch between the blob and the checksum. Aside from security implications,
+                # violations of the immutable blob policy could also cause data integrity failures.
+                file: File = File.objects.select_for_update().get(pk=serializer.instance.pk)
+                if file.blob:
+                    raise serializers.ValidationError(
+                        {'blob': ["A file's blob may only be set once."]}
+                    )
+
+                serializer.save()
+
             file_compute_sha512.delay(file.pk)
+        else:
+            serializer.save()
 
     @swagger_auto_schema(
         responses={

--- a/dkc/core/tests/test_file_rest.py
+++ b/dkc/core/tests/test_file_rest.py
@@ -55,6 +55,12 @@ def test_file_rest_cannot_update_size(admin_api_client, file):
 
 
 @pytest.mark.django_db
+def test_file_rest_update(admin_api_client, file):
+    resp = admin_api_client.patch(f'/api/v2/files/{file.id}', data={'description': 'hello'})
+    assert resp.status_code == 200
+
+
+@pytest.mark.django_db
 def test_file_rest_set_blob(admin_api_client, pending_file, s3ff_field_value, mocker):
     mocker.patch.object(file_compute_sha512, 'delay')
     resp = admin_api_client.patch(

--- a/dkc/core/tests/test_file_rest.py
+++ b/dkc/core/tests/test_file_rest.py
@@ -65,6 +65,13 @@ def test_file_rest_set_blob(admin_api_client, pending_file, s3ff_field_value):
 
 
 @pytest.mark.django_db
+def test_file_rest_set_blob_only_once(admin_api_client, file, s3ff_field_value):
+    resp = admin_api_client.patch(f'/api/v2/files/{file.id}', data={'blob': s3ff_field_value})
+    assert resp.status_code == 400
+    assert resp.data['blob'] == ["A file's blob may only be set once."]
+
+
+@pytest.mark.django_db
 def test_quota_enforcement(admin_api_client, folder):
     resp = admin_api_client.post(
         '/api/v2/files',


### PR DESCRIPTION
This now computes SHA-512 on files after their blob is set, i.e. at the closure of the upload flow. This PR attempts to provide at-most-once semantics for setting a blob on a file. Computing the checksum is an idempotent task, but it's important for security reasons that a blob is not able to be set more than once, otherwise it would be possible to forge a checksum via a race condition on the celery tasks. With that in mind, reviewers should convince themselves that the use of `select_for_update` sufficiently enforces this policy.