### PR TITLE
Make folder deletion asynchronous

### DIFF
--- a/dkc/core/rest/folder.py
+++ b/dkc/core/rest/folder.py
@@ -22,6 +22,7 @@ from dkc.core.permissions import (
     PermissionFilterBackend,
     PermissionGrant,
 )
+from dkc.core.tasks import delete_folder
 
 from .filtering import ActionSpecificFilterBackend, IntegerOrNullFilter
 from .utils import FormattableDict
@@ -205,6 +206,11 @@ class FolderViewSet(ModelViewSet):
             tree = Tree.objects.create(quota=user.quota)
             tree.grant_permission(PermissionGrant(user_or_group=user, permission=Permission.admin))
         serializer.save(tree=tree, creator=user)
+
+    def destroy(self, request, *args, **kwargs):
+        folder = self.get_object()
+        delete_folder.delay(folder.id)
+        return Response(status=202)
 
     @swagger_auto_schema(
         operation_description='Retrieve the path from the root folder to the requested folder.',

--- a/dkc/core/tasks.py
+++ b/dkc/core/tasks.py
@@ -1,6 +1,6 @@
 from celery import shared_task
 
-from dkc.core.models import File
+from dkc.core.models import File, Folder
 
 
 @shared_task()
@@ -8,3 +8,8 @@ def file_compute_sha512(file_id: int):
     file = File.objects.get(pk=file_id)
     file.compute_sha512()
     file.save()
+
+
+@shared_task()
+def delete_folder(folder_id: int):
+    Folder.objects.get(pk=folder_id).delete()

--- a/dkc/core/tests/test_folder_rest.py
+++ b/dkc/core/tests/test_folder_rest.py
@@ -1,7 +1,8 @@
 from django.conf import settings
 import pytest
 
-from dkc.core.models import File, Folder, Tree
+from dkc.core.models import Folder
+from dkc.core.tasks import delete_folder
 
 
 @pytest.mark.django_db
@@ -147,27 +148,11 @@ def test_folder_rest_update_parent_disallowed(admin_api_client, folder, folder_f
 
 
 @pytest.mark.django_db
-def test_folder_rest_destroy(admin_api_client, folder):
+def test_folder_rest_destroy_async(admin_api_client, folder, mocker):
+    mocker.patch.object(delete_folder, 'delay')
     resp = admin_api_client.delete(f'/api/v2/folders/{folder.id}')
-    assert resp.status_code == 204
-    with pytest.raises(Folder.DoesNotExist):
-        Folder.objects.get(id=folder.id)
-
-    with pytest.raises(Tree.DoesNotExist):
-        Tree.objects.get(pk=folder.tree_id)
-
-
-@pytest.mark.django_db
-def test_folder_rest_destroy_recursive(admin_api_client, folder, folder_factory, file_factory):
-    child = folder_factory(parent=folder)
-    file = file_factory(folder=folder)
-    resp = admin_api_client.delete(f'/api/v2/folders/{folder.id}')
-    assert resp.status_code == 204
-    with pytest.raises(Folder.DoesNotExist):
-        Folder.objects.get(id=child.id)
-
-    with pytest.raises(File.DoesNotExist):
-        File.objects.get(id=file.id)
+    assert resp.status_code == 202
+    delete_folder.delay.assert_called_once_with(folder.id)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Recursive folder deletion will often take longer than 30 seconds. If clients wish to be clever, they can handle this 202 as they see fit.