### PR TITLE
Optimize anonymous user tree access

### DIFF
--- a/dkc/core/models/tree.py
+++ b/dkc/core/models/tree.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Type
+from typing import TYPE_CHECKING, Dict, List, Set, Type
 
 from django.contrib.auth.models import Group, User
 from django.contrib.contenttypes.models import ContentType
@@ -138,9 +138,9 @@ class Tree(models.Model):
         existing_grant_set = set(self.list_granted_permissions())
         self.remove_permission_list(list(existing_grant_set - grant_set))
 
-    def get_access(self, user: Optional[User]) -> Dict[str, bool]:
+    def get_access(self, user: User) -> Dict[str, bool]:
         """Return the permissions that the given user has on this entity."""
-        if user is None:
+        if user.is_anonymous:
             # This is a special case for the anonymous user.  Access can only
             # be 'read', and only for public trees.
             access = {p.name: False for p in Permission}

--- a/dkc/core/rest/file.py
+++ b/dkc/core/rest/file.py
@@ -52,7 +52,7 @@ class FileSerializer(serializers.ModelSerializer):
         ]
 
     def get_access(self, file: File) -> Dict[str, bool]:
-        return file.folder.tree.get_access(self.context.get('user'))
+        return file.folder.tree.get_access(self.context['user'])
 
     def validate(self, attrs):
         self._validate_unique_folder_siblings(attrs)

--- a/dkc/core/rest/folder.py
+++ b/dkc/core/rest/folder.py
@@ -62,7 +62,7 @@ class FolderSerializer(serializers.ModelSerializer):
         ]
 
     def get_access(self, folder: Folder) -> Dict[str, bool]:
-        return folder.tree.get_access(self.context.get('user'))
+        return folder.tree.get_access(self.context['user'])
 
     def validate(self, attrs):
         self._validate_unique_root_name(attrs)


### PR DESCRIPTION
This brought the time of listing 7 folders from ~3 sec to around ~250ms in the anonymous user case. This was a simple matter of not correctly detecting anonymous users, for which we have an optimized path.

Let's merge this and I'll follow up with other optimizations in other PRs.